### PR TITLE
Compliance issue fixes

### DIFF
--- a/databricks-workspace/azuredeploy.json
+++ b/databricks-workspace/azuredeploy.json
@@ -60,6 +60,9 @@
           "enableNoPublicIp": {
             "value": "[parameters('disablePublicIp')]"
           }
+        },
+        "enableNoPublicIp": {
+          "value": true
         }
       }
     }

--- a/storage/StorageA/blob.azuredeploy.json
+++ b/storage/StorageA/blob.azuredeploy.json
@@ -1,5 +1,4 @@
 {
-    
     "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
@@ -36,7 +35,7 @@
         "containerName": {
             "type": "string"
         },
-        "workspaceName" : {
+        "workspaceName": {
             "type": "string",
             "defaultValue": "GEN-UNIQUE"
         },
@@ -103,36 +102,36 @@
             }
         },
         {
-            "type" : "Microsoft.Storage/storageAccounts/blobServices/providers/diagnosticsettings",
+            "type": "Microsoft.Storage/storageAccounts/blobServices/providers/diagnosticsettings",
             "name": "[concat(parameters('storageAccountName'), '/blobServices/', '/microsoft.insights/', parameters('storageAccountName'), 'LogSettings')]",
             "apiVersion": "2017-05-01-preview",
             "properties": {
-              "workspaceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]",
-              "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageSinkName'))]",
-              "logs": [
-                  {
-                      "category": "StorageRead",
-                      "enabled": false
-                  },
-                  {
-                      "category": "StorageWrite",
-                      "enabled": true
-                  },
-                  {
-                      "category": "StorageDelete",
-                      "enabled": true
-                  }
-              ],
-              "metrics": [
-                  {
-                      "category": "Transaction",
-                      "enabled": true
-                  }
-              ]
+                "workspaceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]",
+                "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageSinkName'))]",
+                "logs": [
+                    {
+                        "category": "StorageRead",
+                        "enabled": false
+                    },
+                    {
+                        "category": "StorageWrite",
+                        "enabled": true
+                    },
+                    {
+                        "category": "StorageDelete",
+                        "enabled": true
+                    }
+                ],
+                "metrics": [
+                    {
+                        "category": "Transaction",
+                        "enabled": true
+                    }
+                ]
             }
         },
         {
-            "type" : "Microsoft.Storage/storageAccounts/queueservices/providers/diagnosticsettings",
+            "type": "Microsoft.Storage/storageAccounts/queueservices/providers/diagnosticsettings",
             "apiVersion": "2017-05-01-preview",
             "name": "[concat(parameters('storageAccountName'), '/queueservices/', '/microsoft.insights/', parameters('storageAccountName'), 'LogSettings')]",
             "properties": {
@@ -161,7 +160,7 @@
             }
         },
         {
-            "type" : "Microsoft.Storage/storageAccounts/tableservices/providers/diagnosticsettings",
+            "type": "Microsoft.Storage/storageAccounts/tableservices/providers/diagnosticsettings",
             "apiVersion": "2017-05-01-preview",
             "name": "[concat(parameters('storageAccountName'), '/tableservices/', '/microsoft.insights/', parameters('storageAccountName'), 'LogSettings')]",
             "properties": {

--- a/storage/StorageB/deploy.json
+++ b/storage/StorageB/deploy.json
@@ -1,5 +1,4 @@
 {
-    
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
@@ -72,16 +71,7 @@
             "properties": {
                 "networkAcls": {
                     "bypass": "None",
-                    "virtualNetworkRules": [
-                        {
-                            "id": "[variables('containerSubnetRef')]",
-                            "action": "Allow"
-                        },
-                        {
-                            "id": "[variables('storageSubnetRef')]",
-                            "action": "Allow"
-                        }
-                    ],
+                    "virtualNetworkRules": [],
                     "defaultAction": "Deny"
                 },
                 "supportsHttpsTrafficOnly": true,
@@ -183,7 +173,8 @@
                 },
                 "accessTier": "Cool"
             }
-        },{
+        },
+        {
             "type": "Microsoft.Storage/storageAccounts",
             "apiVersion": "2019-06-01",
             "name": "[parameters('storageAccountName3')]",
@@ -196,9 +187,7 @@
             "properties": {
                 "networkAcls": {
                     "bypass": "None",
-                    "virtualNetworkRules": [
-  
-                    ],
+                    "virtualNetworkRules": [],
                     "defaultAction": "Allow"
                 },
                 "supportsHttpsTrafficOnly": true,

--- a/storage/StorageC/storage.azuredeploy.json
+++ b/storage/StorageC/storage.azuredeploy.json
@@ -1,5 +1,4 @@
 {
-    
     "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
@@ -7,31 +6,31 @@
             "type": "string",
             "metadata": {
                 "description": "Location of the storagr account"
-              }
+            }
         },
         "storageAccountName": {
             "type": "string",
             "metadata": {
                 "description": "Name of the storage account"
-              }
+            }
         },
         "accountType": {
             "type": "string",
             "metadata": {
                 "description": "Type of account i.e Standard/Premium LRS/GRS"
-              }
+            }
         },
         "kind": {
             "type": "string",
             "metadata": {
                 "description": "Kind of storag account required for teh storage account"
-              }
+            }
         },
         "accessTier": {
             "type": "string",
             "metadata": {
                 "description": "Access Tier of the storage account default Hot, will chnage it to the Cold "
-              }
+            }
         },
         "minimumTlsVersion": {
             "type": "string"
@@ -43,7 +42,7 @@
             "type": "bool",
             "metadata": {
                 "description": "Allow Blob public access to Blob storage"
-              }
+            }
         },
         "networkAclsBypass": {
             "type": "string"


### PR DESCRIPTION



**databricks-workspace/azuredeploy.json:**
**Violation:** PR-AZR-ARM-DBK-001 (Azure Databricks should not use public IP address)
**Violation Description:** Azure Databricks is a data analytics platform optimized for the Microsoft Azure cloud services platform. This policy will identify Databricks which does not have public ip disabled and warn.
**How to Fix:** In Resource of type "microsoft.databricks/workspaces" make sure properties.parameters.enableNoPublicIp exist and its value set to true.<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.databricks/workspaces?tabs=json' target='_blank'>here</a> for details.


**storage/StorageA/blob.azuredeploy.json:**
**Violation:** PR-AZR-ARM-STR-004 (Storage Accounts should have firewall rules enabled)
**Violation Description:** Turning on firewall rules for your storage account blocks incoming requests for data by default, unless the requests come from a service that is operating within an Azure Virtual Network (VNet). Requests that are blocked include those from other Azure services, from the Azure portal, from logging and metrics services, and so on.<br><br>You can grant access to Azure services that operate from within a VNet by allowing the subnet of the service instance. Enable a limited number of scenarios through the Exceptions mechanism described in the following section. To access the Azure portal, you would need to be on a machine within the trusted boundary (either IP or VNet) that you set up.
**How to Fix:** Make sure you are following the ARM template guidelines for storage accounts by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.storage/storageaccounts' target='_blank'>here</a>. networkAcls should be configured


**storage/StorageB/deploy.json:**
**Violation:** PR-AZR-ARM-STR-004 (Storage Accounts should have firewall rules enabled)
**Violation Description:** Turning on firewall rules for your storage account blocks incoming requests for data by default, unless the requests come from a service that is operating within an Azure Virtual Network (VNet). Requests that are blocked include those from other Azure services, from the Azure portal, from logging and metrics services, and so on.<br><br>You can grant access to Azure services that operate from within a VNet by allowing the subnet of the service instance. Enable a limited number of scenarios through the Exceptions mechanism described in the following section. To access the Azure portal, you would need to be on a machine within the trusted boundary (either IP or VNet) that you set up.
**How to Fix:** Make sure you are following the ARM template guidelines for storage accounts by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.storage/storageaccounts' target='_blank'>here</a>. networkAcls should be configured


**storage/StorageC/storage.azuredeploy.json:**
**Violation:** PR-AZR-ARM-STR-004 (Storage Accounts should have firewall rules enabled)
**Violation Description:** Turning on firewall rules for your storage account blocks incoming requests for data by default, unless the requests come from a service that is operating within an Azure Virtual Network (VNet). Requests that are blocked include those from other Azure services, from the Azure portal, from logging and metrics services, and so on.<br><br>You can grant access to Azure services that operate from within a VNet by allowing the subnet of the service instance. Enable a limited number of scenarios through the Exceptions mechanism described in the following section. To access the Azure portal, you would need to be on a machine within the trusted boundary (either IP or VNet) that you set up.
**How to Fix:** Make sure you are following the ARM template guidelines for storage accounts by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.storage/storageaccounts' target='_blank'>here</a>. networkAcls should be configured