### PR TITLE
Compliance issue fixes

### DIFF
--- a/AKS/aks.azuredeploy.json
+++ b/AKS/aks.azuredeploy.json
@@ -76,7 +76,7 @@
         },
         "enableHttpApplicationRouting": {
             "type": "bool",
-            "defaultValue": true,
+            "defaultValue": false,
             "metadata": {
                 "description": "Boolean flag to turn on and off http application routing."
             }
@@ -191,50 +191,50 @@
             "type": "string"
         },
         "aadProfileManaged": {
-          "defaultValue": false,
-          "type": "bool",
-          "metadata": {
-            "description": "Specifies whether to enable managed AAD integration."
-          }
+            "defaultValue": true,
+            "type": "bool",
+            "metadata": {
+                "description": "Specifies whether to enable managed AAD integration."
+            }
         },
         "aadProfileEnableAzureRBAC": {
-          "defaultValue": false,
-          "type": "bool",
-          "metadata": {
-            "description": "Specifies whether to  to enable Azure RBAC for Kubernetes authorization."
-          }
+            "defaultValue": true,
+            "type": "bool",
+            "metadata": {
+                "description": "Specifies whether to  to enable Azure RBAC for Kubernetes authorization."
+            }
         },
         "aadProfileAdminGroupObjectIDs": {
-          "defaultValue": [],
-          "type": "array",
-          "metadata": {
-            "description": "Specifies the AAD group object IDs that will have admin role of the cluster."
-          }
+            "defaultValue": [],
+            "type": "array",
+            "metadata": {
+                "description": "Specifies the AAD group object IDs that will have admin role of the cluster."
+            }
         },
         "clientAppID": {
             "type": "string",
             "metadata": {
-              "description": "The client AAD application ID."
+                "description": "The client AAD application ID."
             }
         },
         "serverAppID": {
             "type": "string",
             "metadata": {
-              "description": "The server AAD application ID."
+                "description": "The server AAD application ID."
             }
         },
         "serverAppSecret": {
             "type": "string",
             "metadata": {
-              "description": "The server AAD application secret."
+                "description": "The server AAD application secret."
             }
         },
         "aadProfileTenantId": {
-          "defaultValue": "[subscription().tenantId]",
-          "type": "string",
-          "metadata": {
-            "description": "Specifies the tenant id of the Azure Active Directory used by the AKS cluster for authentication."
-          }
+            "defaultValue": "[subscription().tenantId]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the tenant id of the Azure Active Directory used by the AKS cluster for authentication."
+            }
         }
     },
     "variables": {
@@ -255,7 +255,7 @@
                     {
                         "name": "prancer",
                         "osDiskSizeGB": "[parameters('osDiskSizeGB')]",
-                        "count": 1,
+                        "count": 3,
                         "vmSize": "Standard_DS2_v2",
                         "osType": "Linux",
                         "storageProfile": "ManagedDisks",
@@ -275,13 +275,13 @@
                     "dockerBridgeCidr": "[parameters('dockerBridgeCidr')]"
                 },
                 "aadProfile": {
-                  "managed": "[parameters('aadProfileManaged')]",
-                  "enableAzureRBAC": "[parameters('aadProfileEnableAzureRBAC')]",
-                  "adminGroupObjectIDs": "[parameters('aadProfileAdminGroupObjectIDs')]",
-                  "clientAppID": "[parameters('clientAppID')]",
-                  "serverAppID": "[parameters('serverAppID')]",
-                  "serverAppSecret": "[parameters('serverAppSecret')]",
-                  "tenantID": "[parameters('aadProfileTenantId')]"
+                    "managed": "[parameters('aadProfileManaged')]",
+                    "enableAzureRBAC": "[parameters('aadProfileEnableAzureRBAC')]",
+                    "adminGroupObjectIDs": "[parameters('aadProfileAdminGroupObjectIDs')]",
+                    "clientAppID": "[parameters('clientAppID')]",
+                    "serverAppID": "[parameters('serverAppID')]",
+                    "serverAppSecret": "[parameters('serverAppSecret')]",
+                    "tenantID": "[parameters('aadProfileTenantId')]"
                 },
                 "apiServerAccessProfile": {
                     "enablePrivateCluster": "[parameters('enablePrivateCluster')]"
@@ -323,9 +323,7 @@
                         {
                             "type": "Microsoft.Network/virtualNetworks/subnets/providers/roleAssignments",
                             "apiVersion": "2017-05-01",
-                            
                             "name": "[concat(parameters('VirtualNetworkName'), '/', parameters('SubnetName'), '/Microsoft.Authorization/', guid(resourceGroup().id, deployment().name))]",
-                            
                             "properties": {
                                 "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '4d97b98b-1d4f-4787-a291-c67834d212e7')]",
                                 "principalId": "[reference(parameters('resourceName')).identityProfile.kubeletidentity.objectId]",


### PR DESCRIPTION



**AKS/aks.azuredeploy.json:**
**Violation:** PR-AZR-ARM-AKS-001 (Azure CNI networking should be enabled in Azure AKS cluster)
**Violation Description:** Azure CNI provides the following features over kubenet networking:<br><br>- Every pod in the cluster is assigned an IP address in the virtual network. The pods can directly communicate with other pods in the cluster, and other nodes in the virtual network.<br>- Pods in a subnet that have service endpoints enabled can securely connect to Azure services, such as Azure Storage and SQL DB.<br>- You can create user-defined routes (UDR) to route traffic from pods to a Network Virtual Appliance.<br>- Support for Network Policies securing communication between pods.<br><br>This policy checks your AKS cluster for the Azure CNI network plugin and generates an alert if not found.
**How to Fix:** Make sure you are following the ARM template guidelines for AKS by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.containerservice/managedclusters' target='_blank'>here</a>

**Violation:** PR-AZR-ARM-AKS-002 (Azure AKS cluster HTTP application routing should be disabled)
**Violation Description:** The HTTP application routing add-on is designed to let you quickly create an ingress controller and access your applications. This add-on is not currently designed for use in a production environment and is not recommended for production use. For production-ready ingress deployments that include multiple replicas and TLS support, see Create an HTTPS ingress controller.
**How to Fix:** Make sure you are following the ARM template guidelines for AKS by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.containerservice/managedclusters' target='_blank'>here</a> for addonProfiles.httpApplicationRouting.enabled

**Violation:** PR-AZR-ARM-AKS-004 (Azure AKS cluster pool profile count should contain 3 nodes or more)
**Violation Description:** Ensure your AKS cluster pool profile count contains 3 or more nodes. This is recommended for a more resilient cluster. (Clusters smaller than 3 may experience downtime during upgrades.)<br><br>This policy checks the size of your cluster pool profiles and alerts if there are fewer than 3 nodes.
**How to Fix:** Make sure you are following the ARM template guidelines for AKS by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.containerservice/managedclusters' target='_blank'>here</a>. Set minCount for Minimum number of nodes for auto-scaling to 3

**Violation:** PR-AZR-ARM-AKS-006 (Managed Azure AD RBAC for AKS cluster should be enabled)
**Violation Description:** Azure Kubernetes Service (AKS) can be configured to use Azure Active Directory (AD) for user authentication. In this configuration, you sign in to an AKS cluster using an Azure AD authentication token. You can also configure Kubernetes role-based access control (Kubernetes RBAC) to limit access to cluster resources based a user's identity or group membership. Visit https://docs.microsoft.com/en-us/azure/aks/azure-ad-rbac for details.
**How to Fix:** Make sure aadProfile property of type object exist in ARM template with boolean managed = true and enableAzureRBAC = true as child property. Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.containerservice/managedclusters?tabs=json#managedclusteraadprofile-object' target='_blank'>here</a> for details.

**Violation:** PR-AZR-ARM-AKS-008 (Ensure AKS cluster network policies are enforced)
**Violation Description:** Network policy options in AKS include two ways to implement a network policy. You can choose between Azure Network Policies or Calico Network Policies. In both cases, the underlying controlling layer is based on Linux IPTables to enforce the specified policies. Policies are translated into sets of allowed and disallowed IP pairs. These pairs are then programmed as IPTable rules.
**How to Fix:** For Resource type 'microsoft.containerservice/managedclusters' make sure networkProfile.networkPolicy exists and the value is set to `azure` or 'calico`.<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.containerservice/managedclusters' target='_blank'>here</a> for more details.